### PR TITLE
Disable paper-plugin.yml by default as they are still experimental

### DIFF
--- a/bukkit/paper.mcdev.template.json
+++ b/bukkit/paper.mcdev.template.json
@@ -84,7 +84,7 @@
     {
       "name": "USE_PAPER_MANIFEST",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     {
       "label": "creator.ui.optional_settings.label",


### PR DESCRIPTION
When selecting Paper the plugin currently uses the `paper-plugin.yml` by default instead of the expected `plugin.yml` even though Paper plugins are still [experimental](https://docs.papermc.io/paper/dev/getting-started/paper-plugins#:~:text=able%20to%20introduce.-,EXPERIMENTAL,-This%20is%20experimental) and should probably not be used by default by people that don't know what that actually entails.