### PR TITLE
Fixed a bug that caused a failure when synchronizing gradle

### DIFF
--- a/bukkit/build.gradle.ft
+++ b/bukkit/build.gradle.ft
@@ -38,7 +38,7 @@ tasks {
     // Configure the Minecraft version for our task.
     // This is the only required configuration besides applying the plugin.
     // Your plugin's jar (or shadowJar if present) will be used automatically.
-    minecraftVersion(${API_VERSION})
+    minecraftVersion("${API_VERSION}")
   }
 }
 

--- a/bukkit/build.gradle.kts.ft
+++ b/bukkit/build.gradle.kts.ft
@@ -37,7 +37,7 @@ tasks {
     // Configure the Minecraft version for our task.
     // This is the only required configuration besides applying the plugin.
     // Your plugin's jar (or shadowJar if present) will be used automatically.
-    minecraftVersion(${API_VERSION})
+    minecraftVersion("${API_VERSION}")
   }
 }
 

--- a/velocity/build.gradle.ft
+++ b/velocity/build.gradle.ft
@@ -30,7 +30,7 @@ tasks {
     // Configure the Velocity version for our task.
     // This is the only required configuration besides applying the plugin.
     // Your plugin's jar (or shadowJar if present) will be used automatically.
-    velocityVersion(${VELOCITY_VERSION})
+    velocityVersion("${VELOCITY_VERSION}")
   }
 }
 

--- a/velocity/build.gradle.kts.ft
+++ b/velocity/build.gradle.kts.ft
@@ -34,7 +34,7 @@ tasks {
     // Configure the Velocity version for our task.
     // This is the only required configuration besides applying the plugin.
     // Your plugin's jar (or shadowJar if present) will be used automatically.
-    velocityVersion(${VELOCITY_VERSION})
+    velocityVersion("${VELOCITY_VERSION}")
   }
 }
 


### PR DESCRIPTION
I made a mistake by omitting the quotes in the argument of the minecraftVersion() and velocityVersion() methods and forgot to fix it, I didn't even remember I created this pull request.