### PR TITLE
Updated shadow plugin

### DIFF
--- a/bukkit/build.gradle.kts.ft
+++ b/bukkit/build.gradle.kts.ft
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "${KOTLIN_VERSION}"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("com.gradleup.shadow") version "8.3.0"
     id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 


### PR DESCRIPTION
Shadow plugin no longer even works in modern Java versions.
Using the [gradleup](https://gradleup.com/shadow/) updated version solves it.
This fixes #10 