### PR TITLE
Fixes #20

### DIFF
--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "${KOTLIN_LOADER_VERSION.toString().split("kotlin.")[1]}"
-    id("fabric-loom") version "1.7.1"
+    id("fabric-loom") version "${VERSIONS.loom}"
     id("maven-publish")
 }
 


### PR DESCRIPTION
This PR fixes #20 : 
> Previously, the template was set to a specific version of Fabric Loom (1.7.1) and didn't use the selected version of the user.
> A simple fix for this is to just use the value ${VERSIONS.loom} instead of the default.

- [X]  It has been tested ?