### PR TITLE
fix(bungeecord): fix dependencies for bungeecord templates.

### DIFF
--- a/bungeecord/.mcdev.template.json
+++ b/bungeecord/.mcdev.template.json
@@ -28,20 +28,15 @@
       "type": "semantic_version",
       "forceDropdown": true,
       "options": [
-        "1.21-R0.1-SNAPSHOT",
-        "1.20-R0.1-SNAPSHOT",
-        "1.19-R0.1-SNAPSHOT",
-        "1.18-R0.1-SNAPSHOT",
-        "1.17-R0.1-SNAPSHOT",
-        "1.16-R0.5-SNAPSHOT",
+        "1.21-R0.3",
+        "1.21-R0.2",
+        "1.21-R0.1",
+        "1.20-R0.2",
+        "1.20-R0.1",
         "1.16-R0.4",
         "1.16-R0.3",
         "1.16-R0.2",
-        "1.16-R0.1",
-        "1.15-SNAPSHOT",
-        "1.14-SNAPSHOT",
-        "1.13-SNAPSHOT",
-        "1.12-SNAPSHOT"
+        "1.16-R0.1"
       ],
       "default": 0
     },

--- a/bungeecord/build.gradle.ft
+++ b/bungeecord/build.gradle.ft
@@ -5,6 +5,9 @@ version = '${BUILD_COORDS.version}'
 
 repositories {
     mavenCentral()
+    maven {
+        url "https://libraries.minecraft.net"
+    }
 }
 
 dependencies {

--- a/bungeecord/build.gradle.ft
+++ b/bungeecord/build.gradle.ft
@@ -5,10 +5,6 @@ version = '${BUILD_COORDS.version}'
 
 repositories {
     mavenCentral()
-    maven {
-        name = "sonatype"
-        url = "https://oss.sonatype.org/content/groups/public/"
-    }
 }
 
 dependencies {

--- a/bungeecord/build.gradle.kts.ft
+++ b/bungeecord/build.gradle.kts.ft
@@ -8,9 +8,6 @@ version = "${BUILD_COORDS.version}"
 
 repositories {
     mavenCentral()
-    maven("https://oss.sonatype.org/content/groups/public/") {
-        name = "sonatype"
-    }
 }
 
 dependencies {

--- a/bungeecord/build.gradle.kts.ft
+++ b/bungeecord/build.gradle.kts.ft
@@ -8,6 +8,9 @@ version = "${BUILD_COORDS.version}"
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://libraries.minecraft.net")
+    }
 }
 
 dependencies {

--- a/bungeecord/pom.xml.ft
+++ b/bungeecord/pom.xml.ft
@@ -76,13 +76,6 @@
     </resources>
   </build>
 
-  <repositories>
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
       <groupId>net.md-5</groupId>


### PR DESCRIPTION
This includes : 
- Versions update
- Removing oss sonatype repository
- Add minecraft.net repository for com.mojang.brigadier on Gradle.