### PR TITLE
Remove old sonatype repositories for Paper and Velocity templates.

### DIFF
--- a/bukkit/build.gradle.ft
+++ b/bukkit/build.gradle.ft
@@ -19,10 +19,6 @@ repositories {
         url = "https://repo.papermc.io/repository/maven-public/"
     }
 #end
-    maven {
-        name = "sonatype"
-        url = "https://oss.sonatype.org/content/groups/public/"
-    }
 }
 
 dependencies {

--- a/bukkit/build.gradle.kts.ft
+++ b/bukkit/build.gradle.kts.ft
@@ -18,9 +18,6 @@ repositories {
         name = "papermc-repo"
     }
 #end
-    maven("https://oss.sonatype.org/content/groups/public/") {
-        name = "sonatype"
-    }
 }
 
 dependencies {

--- a/bukkit/pom.xml.ft
+++ b/bukkit/pom.xml.ft
@@ -88,10 +88,6 @@
         <url>https://repo.papermc.io/repository/maven-public/</url>
       </repository>
 #end
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public/</url>
-    </repository>
   </repositories>
 
   <dependencies>

--- a/velocity/build.gradle.ft
+++ b/velocity/build.gradle.ft
@@ -14,10 +14,6 @@ repositories {
         name = "papermc-repo"
         url = "https://repo.papermc.io/repository/maven-public/"
     }
-    maven {
-        name = "sonatype"
-        url = "https://oss.sonatype.org/content/groups/public/"
-    }
 }
 
 dependencies {

--- a/velocity/build.gradle.kts.ft
+++ b/velocity/build.gradle.kts.ft
@@ -18,9 +18,6 @@ repositories {
     maven("https://repo.papermc.io/repository/maven-public/") {
         name = "papermc-repo"
     }
-    maven("https://oss.sonatype.org/content/groups/public/") {
-        name = "sonatype"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
The OSS Sonatype repository has moved to the central repository, so this repository is now automatically added by Maven or by using mavenCentral() with Gradle.