### PR TITLE
fix(velocity): remove 4.0.0 Velocity version.

### DIFF
--- a/velocity/.mcdev.template.json
+++ b/velocity/.mcdev.template.json
@@ -28,7 +28,6 @@
       "type": "semantic_version",
       "forceDropdown": true,
       "options": [
-        "4.0.0-SNAPSHOT",
         "3.4.0-SNAPSHOT",
         "3.3.0-SNAPSHOT",
         "3.2.0-SNAPSHOT",


### PR DESCRIPTION
This version has been added in PR #24 (my bad).

This has been reported by TheMouseOnTheBarroomFloor on the official discord server : 
> This version is an old version of Velocity, a branch which is no longer supported.

And [Electronicboy](https://github.com/electronicboy) said, on the official Discord of [PaperMC](https://papermc.io/) : 
> 4.x [of Velocity] was abandoned

While still being "usable", it has no support from **PaperMC** and will probably make people think that this version is newer (even if not).