### PR TITLE
Fix fabric license renaming

### DIFF
--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -97,7 +97,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 tasks.jar {
     from("LICENSE") {
-        rename { "${it}_${project.base.archivesName}" }
+        rename { "${it}_${project.base.archivesName.get()}" }
     }
 }
 


### PR DESCRIPTION
`archivesName` is a `Property<String>`, not a `String`.