### PR TITLE
Partially fixes #39

### DIFF
--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -63,14 +63,15 @@ dependencies {
 }
 
 processResources {
+    def mcVer = project.property("minecraft_version").toString().replace("-snapshot-", "-alpha.")
     inputs.property "version", project.version
-    inputs.property "minecraft_version", project.minecraft_version
+    inputs.property "minecraft_version", mcVer
     inputs.property "loader_version", project.loader_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version,
-                "minecraft_version": project.minecraft_version,
+                "minecraft_version": mcVer,
                 "loader_version": project.loader_version
     }
 }

--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '${VERSIONS.loom}'
+    id 'net.fabricmc.fabric-loom' version '${VERSIONS.loom}'
     id 'maven-publish'
 }
 
@@ -42,6 +42,7 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
+#if (${VERSIONS.minecraft.compareTo($mcver.MC1_21_11)} <= 0)
 #if (${VERSIONS.useOfficialMappings})
     mappings loom.officialMojangMappings()
 #else
@@ -51,6 +52,13 @@ dependencies {
 
 #if (${VERSIONS.useFabricApi})
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+#end
+#else
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+#if (${VERSIONS.useFabricApi})
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+#end
 #end
 }
 

--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -1,5 +1,9 @@
 plugins {
+#if (${VERSIONS.minecraft.compareTo($mcver.MC1_21_11)} <= 0)
     id 'net.fabricmc.fabric-loom' version '${VERSIONS.loom}'
+#else
+    id 'fabric-loom' version '${VERSIONS.loom}'
+#end
     id 'maven-publish'
 }
 

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "${KOTLIN_LOADER_VERSION.toString().split("kotlin.")[1]}"
-    id("fabric-loom") version "${VERSIONS.loom}"
+    id("net.fabricmc.fabric-loom") version "${VERSIONS.loom}"
     id("maven-publish")
 }
 
@@ -55,6 +55,7 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")
+#if (${VERSIONS.minecraft.compareTo($mcver.MC1_21_11)} <= 0)
 #if (${VERSIONS.useOfficialMappings})
     mappings(loom.officialMojangMappings())
 #else
@@ -65,6 +66,14 @@ dependencies {
 
 #if (${VERSIONS.useFabricApi})
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+#end
+#else
+    implementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+    implementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
+
+#if (${VERSIONS.useFabricApi})
+    implementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+#end
 #end
 }
 

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -78,16 +78,17 @@ dependencies {
 }
 
 tasks.processResources {
+    val mcVer = project.property("minecraft_version").toString().replace("-snapshot-", "-alpha.")
     inputs.property("version", project.version)
-    inputs.property("minecraft_version", project.property("minecraft_version"))
+    inputs.property("minecraft_version", mcVer)
     inputs.property("loader_version", project.property("loader_version"))
     filteringCharset = "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand("version" to project.version,
-            "minecraft_version" to project.property("minecraft_version"),
-            "loader_version" to project.property("loader_version"),
-            "kotlin_loader_version" to project.property("kotlin_loader_version"))
+            "minecraft_version" to mcVer,
+            "loader_version" to project.property("loader_version").toString(),
+            "kotlin_loader_version" to project.property("kotlin_loader_version").toString())
     }
 }
 

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -3,7 +3,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "${KOTLIN_LOADER_VERSION.toString().split("kotlin.")[1]}"
+#if (${VERSIONS.minecraft.compareTo($mcver.MC1_21_11)} <= 0)
+    id("fabric-loom") version "${VERSIONS.loom}"
+#else
     id("net.fabricmc.fabric-loom") version "${VERSIONS.loom}"
+#end
     id("maven-publish")
 }
 


### PR DESCRIPTION
As said in the title, this partially fixes #39

To be more exact:
* Update to use `implementation` over `modImplementation`
* Fixes the inputs to FMJ to take in Minecraft version strings with `-alpha.` instead of `-snapshot-`
* Adds .toString() to the build.gradle.kts to fix it not launching at all

If desired, I could add something to separate using Kotlin as the DSL and using it as the language used in the mod.