### PR TITLE
Update for Paper 26.1.1

### DIFF
--- a/architectury/.mcdev.template.json
+++ b/architectury/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "mod",
   "properties": [
     {

--- a/bukkit/build.gradle.kts.ft
+++ b/bukkit/build.gradle.kts.ft
@@ -68,11 +68,11 @@ dependencies {
 #elseif ($IS_SPIGOT && $USE_VERSION_CATALOG)
     compileOnly(libs.spigot.api)
 #elseif ($IS_PAPER && !$PAPERWEIGHT_USERDEV_PLUGIN.enabled && !$USE_VERSION_CATALOG)
-    compileOnly("io.papermc.paper:paper-api:${MC_VERSION}-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:${DEPENDENCY_VERSION}")
 #elseif ($IS_PAPER && !$PAPERWEIGHT_USERDEV_PLUGIN.enabled && $USE_VERSION_CATALOG)
     compileOnly(libs.paper.api)
 #elseif ($IS_PAPER && $PAPERWEIGHT_USERDEV_PLUGIN.enabled && !$USE_VERSION_CATALOG)
-    paperweight.paperDevBundle("${MC_VERSION}-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("${DEPENDENCY_VERSION}")
 #elseif ($IS_PAPER && $PAPERWEIGHT_USERDEV_PLUGIN.enabled && $USE_VERSION_CATALOG)
     paperweight.paperDevBundle(libs.versions.paper.api.get())
 #end

--- a/bukkit/libs.versions.toml.ft
+++ b/bukkit/libs.versions.toml.ft
@@ -4,7 +4,7 @@ kotlin = "$KOTLIN_VERSION"
 
 #end
 #if ($IS_PAPER)
-paper-api = "${MC_VERSION}-R0.1-SNAPSHOT"
+paper-api = "${DEPENDENCY_VERSION}"
 #elseif ($IS_SPIGOT)
 spigot-api = "${MC_VERSION}-R0.1-SNAPSHOT"
 #end

--- a/bukkit/paper.mcdev.template.json
+++ b/bukkit/paper.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "plugin",
   "properties": [
     {
@@ -288,6 +288,18 @@
       "type": "boolean",
       "visible": false,
       "default": true
+    },
+    {
+      "name": "DEPENDENCY_VERSION",
+      "type": "string",
+      "derives": {
+        "parents": [
+          "MC_VERSION",
+          "BUILD_SYSTEM"
+        ],
+        "method": "fetchPaperDependencyVersionForMcVersion"
+      },
+      "visible": false
     }
   ],
   "files": [

--- a/bukkit/pom.xml.ft
+++ b/bukkit/pom.xml.ft
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>${MC_VERSION}-R0.1-SNAPSHOT</version>
+      <version>${DEPENDENCY_VERSION}</version>
       <scope>provided</scope>
     </dependency>
 #end

--- a/bukkit/spigot.mcdev.template.json
+++ b/bukkit/spigot.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "plugin",
   "properties": [
     {
@@ -52,6 +52,8 @@
       "type": "semantic_version",
       "forceDropdown": true,
       "options": [
+        "26.1.1",
+        "26.1",
         "1.21.11",
         "1.21.10",
         "1.21.9",

--- a/bungeecord/.mcdev.template.json
+++ b/bungeecord/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "proxy",
   "properties": [
     {

--- a/fabric/.mcdev.template.json
+++ b/fabric/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "mod",
   "properties": [
     {

--- a/forge/.mcdev.template.json
+++ b/forge/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "mod",
   "properties": [
     {

--- a/multiloader/.mcdev.template.json
+++ b/multiloader/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "mod",
   "properties": [
     {

--- a/neoforge/.mcdev.template.json
+++ b/neoforge/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "mod",
   "properties": [
     {

--- a/sponge/.mcdev.template.json
+++ b/sponge/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "plugin",
   "properties": [
     {

--- a/velocity/.mcdev.template.json
+++ b/velocity/.mcdev.template.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "group": "proxy",
   "properties": [
     {


### PR DESCRIPTION
Requires https://github.com/minecraft-dev/MinecraftDev/pull/2606

- adds a new derivative: `fetchPaperDependencyVersionForMcVersion` with the parents `MC_VERSION` and `BUILD_SYSTEM`, which resolves the build string to either `VERSION-R0.1-SNAPSHOT`, `VERSION.build.+`, or `[VERSION.build,)`.
- bumps the template version to `3` in response to the new derivative.
- adds the missing Spigot versions for `26.1` and `26.1.1`.