### PR TITLE
Remove explicit gremlin runtime dependency

### DIFF
--- a/bukkit/build.gradle.kts.ft
+++ b/bukkit/build.gradle.kts.ft
@@ -76,11 +76,6 @@ dependencies {
 #elseif ($IS_PAPER && $PAPERWEIGHT_USERDEV_PLUGIN.enabled && $USE_VERSION_CATALOG)
     paperweight.paperDevBundle(libs.versions.paper.api.get())
 #end
-#if ($GREMLIN_PLUGIN.enabled && !$USE_VERSION_CATALOG)
-    implementation("xyz.jpenilla:gremlin-runtime:$GREMLIN_PLUGIN.version")
-#elseif ($GREMLIN_PLUGIN.enabled && $USE_VERSION_CATALOG)
-    implementation(libs.gremlin.runtime)
-#end
 #if ($LANGUAGE=='Kotlin' && !$USE_VERSION_CATALOG && !$GREMLIN_PLUGIN.enabled)
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 #elseif ($LANGUAGE=='Kotlin' && $USE_VERSION_CATALOG && !$GREMLIN_PLUGIN.enabled)

--- a/bukkit/libs.versions.toml.ft
+++ b/bukkit/libs.versions.toml.ft
@@ -37,9 +37,6 @@ spigot-api = { module = "org.spigotmc:spigot-api", version.ref = "spigot-api" }
 #if ($LANGUAGE=='Kotlin')
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 #end
-#if ($GREMLIN_PLUGIN.enabled)
-gremlin-runtime = { module = "xyz.jpenilla:gremlin-runtime", version.ref = "gremlin" }
-#end
 
 [plugins]
 #if ($PAPERWEIGHT_USERDEV_PLUGIN.enabled)


### PR DESCRIPTION
The gremlin runtime is already automatically included when using the plugin, meaning this declaration was obsolete.