### PR TITLE
Fix fabric templates for MC 26.1+

### DIFF
--- a/fabric/.mcdev.template.json
+++ b/fabric/.mcdev.template.json
@@ -187,7 +187,7 @@
       "template": "../gradle-wrapper.properties.ft",
       "destination": "gradle/wrapper/gradle-wrapper.properties",
       "properties": {
-        "GRADLE_VERSION": "9.2.1"
+        "GRADLE_VERSION": "9.6.1"
       }
     },
     {

--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -1,7 +1,12 @@
 plugins {
+#if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
+	id 'net.fabricmc.fabric-loom' version '${VERSIONS.loom}'
+#else
     id 'fabric-loom' version '${VERSIONS.loom}'
+#end
     id 'maven-publish'
 }
+
 
 version = project.mod_version
 group = project.maven_group
@@ -42,15 +47,23 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-#if (${VERSIONS.useOfficialMappings})
-    mappings loom.officialMojangMappings()
+#if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	
+	#if (${VERSIONS.useFabricApi})
+		implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	#end
 #else
-    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-#end
-    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	#if (${VERSIONS.useOfficialMappings})
+		mappings loom.officialMojangMappings()
+	#else
+		mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	#end
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-#if (${VERSIONS.useFabricApi})
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	#if (${VERSIONS.useFabricApi})
+		modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	#end
 #end
 }
 

--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -7,7 +7,6 @@ plugins {
     id 'maven-publish'
 }
 
-
 version = project.mod_version
 group = project.maven_group
 

--- a/fabric/build.gradle.ft
+++ b/fabric/build.gradle.ft
@@ -1,6 +1,6 @@
 plugins {
 #if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
-	id 'net.fabricmc.fabric-loom' version '${VERSIONS.loom}'
+    id 'net.fabricmc.fabric-loom' version '${VERSIONS.loom}'
 #else
     id 'fabric-loom' version '${VERSIONS.loom}'
 #end
@@ -47,22 +47,22 @@ dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
 #if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
-	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	
-	#if (${VERSIONS.useFabricApi})
-		implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	#end
+    implementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    
+    #if (${VERSIONS.useFabricApi})
+        implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    #end
 #else
-	#if (${VERSIONS.useOfficialMappings})
-		mappings loom.officialMojangMappings()
-	#else
-		mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	#end
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    #if (${VERSIONS.useOfficialMappings})
+        mappings loom.officialMojangMappings()
+    #else
+        mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+    #end
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	#if (${VERSIONS.useFabricApi})
-		modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	#end
+    #if (${VERSIONS.useFabricApi})
+        modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+    #end
 #end
 }
 

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -60,24 +60,24 @@ dependencies {
     // To change the versions see the gradle.properties file
     minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")
 #if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
-	implementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+    implementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
     implementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
-	
-	#if (${VERSIONS.useFabricApi})
-		implementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
-	#end
+    
+    #if (${VERSIONS.useFabricApi})
+        implementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+    #end
 #else
-	#if (${VERSIONS.useOfficialMappings})
-		mappings(loom.officialMojangMappings())
-	#else
-		mappings("net.fabricmc:yarn:${project.property("yarn_mappings")}:v2")
-	#end
-	modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+    #if (${VERSIONS.useOfficialMappings})
+        mappings(loom.officialMojangMappings())
+    #else
+        mappings("net.fabricmc:yarn:${project.property("yarn_mappings")}:v2")
+    #end
+    modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
 
-	#if (${VERSIONS.useFabricApi})
-		modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
-	#end
+    #if (${VERSIONS.useFabricApi})
+        modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+    #end
 #end
 }
 

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -79,6 +79,7 @@ dependencies {
 		modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
 	#end
 #end
+}
 
 tasks.processResources {
     inputs.property("version", project.version)

--- a/fabric/build.gradle.kts.ft
+++ b/fabric/build.gradle.kts.ft
@@ -3,7 +3,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "${KOTLIN_LOADER_VERSION.toString().split("kotlin.")[1]}"
+#if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
+    id("net.fabricmc.fabric-loom") version "${VERSIONS.loom}"
+#else
     id("fabric-loom") version "${VERSIONS.loom}"
+#end
     id("maven-publish")
 }
 
@@ -55,18 +59,26 @@ repositories {
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")
-#if (${VERSIONS.useOfficialMappings})
-    mappings(loom.officialMojangMappings())
+#if ($VERSIONS.minecraftVersion.compareTo($mcver.MC26_1) >= 0)
+	implementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+    implementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
+	
+	#if (${VERSIONS.useFabricApi})
+		implementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+	#end
 #else
-    mappings("net.fabricmc:yarn:${project.property("yarn_mappings")}:v2")
-#end
-    modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
+	#if (${VERSIONS.useOfficialMappings})
+		mappings(loom.officialMojangMappings())
+	#else
+		mappings("net.fabricmc:yarn:${project.property("yarn_mappings")}:v2")
+	#end
+	modImplementation("net.fabricmc:fabric-loader:${project.property("loader_version")}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
 
-#if (${VERSIONS.useFabricApi})
-    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+	#if (${VERSIONS.useFabricApi})
+		modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
+	#end
 #end
-}
 
 tasks.processResources {
     inputs.property("version", project.version)


### PR DESCRIPTION
Simple fix to the build.gradle files for 26.1+ fabric mods
[As detailed here](https://fabricmc.net/2026/03/14/261.html#unobfuscated-loom)

Also increased `GRADLE_VERSION` to **9.6.1**, 
as 26.1 requires gradle 9.4.0+ and 26.2 gradle 9.5.1+.

Fixes #53 and minecraft-dev/MinecraftDev#2614

I tested that the generated (Java) template mods successfully compiled without intervention for MC 26.2, 26.1 (fix) and 1.21.11 (same as old template), suggesting no regression